### PR TITLE
added: CFF Explorer.

### DIFF
--- a/bucket/CFFExplorer.json
+++ b/bucket/CFFExplorer.json
@@ -1,0 +1,25 @@
+{
+	"homepage": "https://ntcore.com/?page_id=388",
+	"description": "A PE editor with full support of PE32/64/.NET",
+	"license": {
+		"identifier": "Freeware"
+	},
+	"version": "III",
+	"url": "https://ntcore.com/files/CFF_Explorer.zip",
+	"hash": "8e72bcb9c6e83f188f4a259ad039ed3cc37cdf2c3ea12b00f0df8d8b67e96d96",
+	"extract_dir": "CFF_Explorer",
+	"bin": "CFF Explorer.exe",
+	"checkver": {
+		"url": "https://ntcore.com/?page_id=388",
+		"regex": "Current Version:\\s([A-Z0-9.]+)"
+	},
+	"autoupdate": {
+		"url": "https://ntcore.com/files/CFF_Explorer.zip"
+	},
+	"shortcuts": [
+		[
+			"CFF Explorer.exe",
+			"CFF Explorer"
+		]
+	]
+}


### PR DESCRIPTION
Not checkver or autoupdate, though – app seems to be stable for now.

Fixes #14.